### PR TITLE
no_formula_terms exception

### DIFF
--- a/odvc/__init__.py
+++ b/odvc/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 __version__ = '0.0.1'
 

--- a/odvc/formulas.py
+++ b/odvc/formulas.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import numpy as np
 

--- a/odvc/utils.py
+++ b/odvc/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import netCDF4
 from biggus import NumpyArrayAdapter
@@ -18,7 +19,12 @@ def get_formula_terms_variables(nc):
 
     """
     func = lambda v: v is not None
-    return nc.get_variables_by_attributes(formula_terms=func)
+    var = nc.get_variables_by_attributes(formula_terms=func)
+    if not var:
+        msg = ("Could not find the attribute `formula_terms` in any of the "
+               "{!r} variables.").format
+        raise ValueError(msg(nc))
+    return var
 
 
 def get_formula_terms(var):


### PR DESCRIPTION
Added an `Exception` when the `formula_terms` attribute is not found in any of the `nc` object variables.